### PR TITLE
Leg 376 asset cards zoom in on hover

### DIFF
--- a/src/components/gallery/cards/assetCard.vue
+++ b/src/components/gallery/cards/assetCard.vue
@@ -36,7 +36,7 @@ export default defineComponent({
 
 <template lang="pug">
 q-card
-  q-card-section
+  q-card-section.bg-white(style='z-index: 2')
     .row
       .col
         .row
@@ -54,11 +54,12 @@ q-card
         ) {{ card.tier }}
   q-separator(inset)
   router-link(:to='card.to')
-    q-img.asset-img(:src='card.imageUrl')
+    q-img.asset-img.zoom(:src='card.imageUrl')
 </template>
 
 <style lang="sass" scoped>
 .asset-img
+  z-index: 1
   width: 100%
   height: 500px
   max-height: 400px

--- a/src/components/gallery/cards/auctionCard.vue
+++ b/src/components/gallery/cards/auctionCard.vue
@@ -37,7 +37,7 @@ export default defineComponent({
 
 <template lang="pug">
 q-card
-  q-card-section
+  q-card-section.bg-white(style='z-index: 2')
     q-badge.text-subtitle2.float-right.text(
       v-if='card.tier',
       rounded,
@@ -58,11 +58,12 @@ q-card
         CountDown(:endDate='new Date(card.saleclose)')
   q-separator(inset)
   router-link(:to='card.to')
-    q-img.asset-img(:src='card.imageUrl')
+    q-img.asset-img.zoom(:src='card.imageUrl')
 </template>
 
 <style lang="sass" scoped>
 .asset-img
+  z-index: 1
   width: 100%
   height: 500px
   max-height: 400px

--- a/src/components/gallery/cards/templateCard.vue
+++ b/src/components/gallery/cards/templateCard.vue
@@ -36,7 +36,7 @@ export default defineComponent({
 
 <template lang="pug">
 q-card
-  q-card-section
+  q-card-section.bg-white(style='z-index: 2')
     .row
       .col
         .row
@@ -52,11 +52,12 @@ q-card
   router-link(
     :to='{ name: "template", params: { collection_name: card.collection, template_id: card.id } }'
   )
-    q-img.asset-img(:src='card.imageUrl')
+    q-img.asset-img.zoom(:src='card.imageUrl')
 </template>
 
 <style lang="sass" scoped>
 .asset-img
+  z-index: 1
   width: 100%
   height: 500px
   max-height: 400px

--- a/src/css/app.sass
+++ b/src/css/app.sass
@@ -41,3 +41,8 @@ body
 .login-card
     border-radius: 20px 20px 20px 20px
 
+.zoom
+  transition: transform .3s
+
+.zoom:hover
+  transform: scale(1.1)


### PR DESCRIPTION
# Description
- Added zoom class to zoom components on hover
- Applied zoom class to asset images

# Notes
- Images only zoom if they are hovered, not their card. Let me know if this is preferred. I did it this way, because only clicking the image routes the user to the asset.